### PR TITLE
Avoid overflow when casting integer

### DIFF
--- a/utils/ffcfstress.c
+++ b/utils/ffcfstress.c
@@ -287,7 +287,7 @@ void update_device(double force, double * position)
 	/* Get events */
 	while (read(device_handle,&event,sizeof(event))==sizeof(event)) {
 		if (event.type==EV_ABS && event.code==axis_code) {
-			*position=((double)(((short)event.value)-axis_min))*2.0/(axis_max-axis_min)-1.0;
+			*position=((double)(((unsigned short)event.value)-axis_min))*2.0/(axis_max-axis_min)-1.0;
 			if (*position>1.0) *position=1.0;
 			else if (*position<-1.0) *position=-1.0;
 		}


### PR DESCRIPTION
Hi. I've found a bug in ffcfstress when reading the wheel position. The event.value is cast to a signed short integer. The Logitech Driving Force G29 (and maybe others) returns a value between 0 and 65535 causing this cast to overflow. It should be cast to an unsigned short instead.